### PR TITLE
fix: override postcss to patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.5.6",
         "next": "^16.2.6",
-        "postcss": "^8.5.12",
+        "postcss": "8.5.15",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-icons": "^5.3.0",
@@ -6139,9 +6139,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -6234,34 +6234,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/next/node_modules/sharp": {
@@ -6695,9 +6667,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6714,7 +6686,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.5.6",
     "next": "^16.2.6",
-    "postcss": "^8.5.12",
+    "postcss": "8.5.15",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-icons": "^5.3.0",
@@ -48,6 +48,7 @@
   "overrides": {
     "refractor": {
       "prismjs": "^1.30.0"
-    }
+    },
+    "postcss": "8.5.15"
   }
 }


### PR DESCRIPTION
## Summary
- Update direct `postcss` dependency to `8.5.15`
- Add npm `overrides` so Next's transitive `postcss@8.4.31` resolves to the patched version
- Refresh `package-lock.json`

## Verification
- [x] `npm install --package-lock-only --no-audit`
- [x] `npm ci --ignore-scripts --no-audit`
- [x] `npm ls postcss --all` shows only `postcss@8.5.15`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Full local `npm ci --no-audit`: blocked by the existing `sharp@0.32.5` native install on this machine (`vips/vips8` header missing / no prebuilt binary). The PostCSS resolution itself is verified with ignore-scripts plus lint/build.

Closes Dependabot alert for `postcss` patched in `8.5.10`.
